### PR TITLE
Added end point to get gravity history

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -23,7 +23,7 @@ app.get("/recipe",  getRecipe)
 app.get("/batch",  getBatch)
 app.get("/batch/update",  getBatchUpdate)
 app.get("/get-qr",  genURLQRCode)
-app.get("/batch/get-gravity", getBatchGravity)
+app.get("/batch/get-gravity-history", getBatchGravity)
 
 
 app.post("/recipe/create", restrictAccessMiddleware, createRecipe)

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -3,7 +3,7 @@ import bodyParser from "body-parser"
 import cors from "cors"
 
 import { config } from "./config"
-import { healthStatus,  createRecipe, getRecipe, deleteRecipe, createBatch, createBatchUpdate, getBatch, deleteBatch, deleteBatchUpdate, getBatchUpdate, whoami, genURLQRCode} from "./handlers"
+import { healthStatus,  createRecipe, getRecipe, deleteRecipe, createBatch, createBatchUpdate, getBatch, deleteBatch, deleteBatchUpdate, getBatchUpdate, whoami, genURLQRCode, getBatchGravity} from "./handlers"
 import { authMiddleware } from "./lib/authMiddleware"
 import { restrictAccessMiddleware } from "./lib/restrictAccessMiddleware"
 
@@ -23,6 +23,8 @@ app.get("/recipe",  getRecipe)
 app.get("/batch",  getBatch)
 app.get("/batch/update",  getBatchUpdate)
 app.get("/get-qr",  genURLQRCode)
+app.get("/batch/get-gravity", getBatchGravity)
+
 
 app.post("/recipe/create", restrictAccessMiddleware, createRecipe)
 app.post("/recipe/delete", restrictAccessMiddleware, deleteRecipe)

--- a/backend/docs/api-docs.md
+++ b/backend/docs/api-docs.md
@@ -277,6 +277,68 @@ Parameters schema:
 Example request url:
 https://api.meadarchive.com/get-qr?url=https://meadarchive.com/batch/aae2f0c1-1287-4c41-9756-87adc2be9582&correction=H
 
+
+### GET `/batch/get-gravity-history`
+This endpoint returns the gravity history for a batch. The `batchID` must be passed in the query string. The responce will be an array of objects containing the gravity and date for each update (as a unix time stamp).
+
+Requires authentication: `No`
+
+Parameters schema:
+
+| Parameter | Type | Description | Optional/Required |
+| --- | --- | --- | --- |
+| `batchID`  | `string` | The id of the batch to return gravity history for | Required
+
+
+Example response:
+```json
+{
+    "gravityData": [
+        {
+            "date": "1704586077",
+            "gravity": 1
+        },
+        {
+            "date": "1704660861947",
+            "gravity": 0.99
+        },
+        {
+            "date": "1704660881084",
+            "gravity": 0.95
+        }
+    ]
+}
+```
+
+#### ok response:
+
+Status: `200`
+
+#### BatchID is null or undefined response:
+
+```json
+{"error": "Batch ID is null or undefined"}
+```
+
+Status: `400`
+
+#### Batch not found response:
+
+```json
+{"error": "No batch with id '7009363b-396b-4f65-89b7-f064e8c54ae9' exists"}
+```
+
+Status: `400`
+
+#### Any other error response:
+
+```json
+{"error": "Internal server error during gravity history retrival"}
+```
+
+Status: `500`
+
+
 <br>
 
 ### POST `/recipe/create`

--- a/backend/handlers.ts
+++ b/backend/handlers.ts
@@ -1,7 +1,7 @@
 import express from "express";
 
 import { config } from "./config"
-import { Recipe, RecipeSchema, Batch, BatchSchema, BaseBatchUpdate, TextBatchUpdate, GravityBatchUpdate, StageBatchUpdate, TextBatchUpdateSchema, GravityBatchUpdateSchema, StageBatchUpdateSchema} from "./lib/customTypes";
+import { Recipe, RecipeSchema, Batch, BatchSchema, BaseBatchUpdate, TextBatchUpdate, GravityBatchUpdate, StageBatchUpdate, TextBatchUpdateSchema, GravityBatchUpdateSchema, StageBatchUpdateSchema, BatchWithUpdates, DictionaryOfBatchUpdates} from "./lib/customTypes";
 import { firebaseInsertRecipe, firebaseGetRecipes, firebaseDeleteRecipe, checkIfUserOwnsRecipe, checkIfRecipeExists} from "./lib/recipeLib"
 import { firebaseInsertBatch, firebaseInsertBatchUpdate, checkIfBatchExists, firebaseGetBatches, checkIfUserOwnsBatch, firebaseDeleteBatch, checkIfUpdateExits, firebaseDeleteBatchUpdate, firebaseGetBatchUpdate} from "./lib/batchLib"
 import { genUID, getUserInfoByID} from "./lib/util"
@@ -387,6 +387,60 @@ export async function genURLQRCode(req: express.Request, res: express.Response){
     } catch (err){
         console.log(err)
         res.status(500).send({ "error": `Internal server error while generating QR code`});
+    }
+
+}
+
+export async function getBatchGravity(req: express.Request, res: express.Response){
+    try{
+        const batchID = req.query.batchID as string | null ?? null
+
+        if (!batchID){
+            res.status(400).send({"error": `"batchID" is null or undefined`})
+            return
+        }
+
+        const batchExists = await checkIfBatchExists(batchID, config.batchesCollectionName)
+
+        if(!batchExists){
+            res.status(400).send({"error": `No batch with id '${batchID}' exists`})
+            return
+        }
+
+        let batches = await firebaseGetBatches(batchID, null, config.batchesCollectionName)
+        const batch: BatchWithUpdates = batches[batchID]
+        const initialGravity = batch.initialGravity
+
+        const updates: DictionaryOfBatchUpdates = batch.updates
+
+        let gravityUpdates = Object.values(updates).filter(update => update.updateType == "gravity") as GravityBatchUpdate[]
+
+        // transform into an array of [{"date": "2021-01-01", "gravity": 1.000}, ...]
+        let gravityData = gravityUpdates.map(update => {
+            return {"date": update.updateDate, "gravity": update.newGravity}
+        })
+
+        // Insert the initial gravity at index 0
+        gravityData.unshift({"date": batch.dateStarted, "gravity": initialGravity})
+
+        // Sort by date, oldest to newest
+        gravityData.sort((a, b) => {
+            return new Date(a.date).getTime() - new Date(b.date).getTime()
+        })
+
+        console.log(gravityData)
+
+        res.send({"gravityData": gravityData})
+
+
+
+
+        
+
+
+    } catch (err){
+        console.log(err)
+        res.status(500).send({ "error": `Internal server error while getting batch gravity`});
     }
 
 }

--- a/backend/handlers.ts
+++ b/backend/handlers.ts
@@ -394,12 +394,14 @@ export async function genURLQRCode(req: express.Request, res: express.Response){
 export async function getBatchGravity(req: express.Request, res: express.Response){
     try{
         const batchID = req.query.batchID as string | null ?? null
-
+        
+        // Check if batchID is null or undefined
         if (!batchID){
             res.status(400).send({"error": `"batchID" is null or undefined`})
             return
         }
-
+        
+        // Check if batch exists
         const batchExists = await checkIfBatchExists(batchID, config.batchesCollectionName)
 
         if(!batchExists){
@@ -407,6 +409,7 @@ export async function getBatchGravity(req: express.Request, res: express.Respons
             return
         }
 
+        // Find gravity batch updates
         let batches = await firebaseGetBatches(batchID, null, config.batchesCollectionName)
         const batch: BatchWithUpdates = batches[batchID]
         const initialGravity = batch.initialGravity
@@ -415,7 +418,7 @@ export async function getBatchGravity(req: express.Request, res: express.Respons
 
         let gravityUpdates = Object.values(updates).filter(update => update.updateType == "gravity") as GravityBatchUpdate[]
 
-        // transform into an array of [{"date": "2021-01-01", "gravity": 1.000}, ...]
+        // Transform into an array of [{"date": "2021-01-01", "gravity": 1.000}, ...]
         let gravityData = gravityUpdates.map(update => {
             return {"date": update.updateDate, "gravity": update.newGravity}
         })
@@ -428,15 +431,7 @@ export async function getBatchGravity(req: express.Request, res: express.Respons
             return new Date(a.date).getTime() - new Date(b.date).getTime()
         })
 
-        console.log(gravityData)
-
         res.send({"gravityData": gravityData})
-
-
-
-
-        
-
 
     } catch (err){
         console.log(err)

--- a/backend/lib/customTypes.ts
+++ b/backend/lib/customTypes.ts
@@ -93,6 +93,15 @@ export type TextBatchUpdate = z.infer<typeof TextBatchUpdateSchema>
 export type GravityBatchUpdate = z.infer<typeof GravityBatchUpdateSchema>
 export type StageBatchUpdate = z.infer<typeof StageBatchUpdateSchema>
 
+export type DictionaryOfBatchUpdates = {
+    [key: string] : TextBatchUpdate | GravityBatchUpdate | StageBatchUpdate
+}
+
+// Batch with a dictionary of updates where the key is the updateID
+export type BatchWithUpdates = Batch & {updates: DictionaryOfBatchUpdates}
+
+
+
 export interface DictionaryOfRecipes {
     [key: string] : Recipe
 }

--- a/backend/lib/customTypes.ts
+++ b/backend/lib/customTypes.ts
@@ -97,13 +97,8 @@ export type DictionaryOfBatchUpdates = {
     [key: string] : TextBatchUpdate | GravityBatchUpdate | StageBatchUpdate
 }
 
-// Batch with a dictionary of updates where the key is the updateID
-export type BatchWithUpdates = Batch & {updates: DictionaryOfBatchUpdates}
-
-
-
 export interface DictionaryOfRecipes {
     [key: string] : Recipe
 }
 
-
+export type BatchWithUpdates = Batch & {updates: DictionaryOfBatchUpdates}


### PR DESCRIPTION
This endpoint finds all relevant gravity updates for a given batch, as well as add the initial gravity, to create a full history along with timestamps.